### PR TITLE
Use text accent color for Vim Mode block cursor

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1162,6 +1162,16 @@ border-bottom:1px solid #999;
   border:none;
   border-right:2px solid var(--text-accent);
 }
+.cm-fat-cursor .CodeMirror-cursor { 
+    background-color: var(--text-accent); 
+    opacity: 0.5; 
+    width: 5px; 
+} 
+.cm-animate-fat-cursor { 
+  background-color: var(--text-accent); 
+  opacity: 0.5; 
+  width: 5px; 
+} 
 .markdown-source-view {
   padding:0;
 }


### PR DESCRIPTION
Hi @kepano, great theme!

I use Vim Mode in Obsidian and with the theme the block cursor when not editing looked a little weird:

- Normal Mode
<img width="509" alt="image" src="https://user-images.githubusercontent.com/12382440/104281349-aa68c380-54ad-11eb-8bfc-965d401e52fd.png">
- Visual Mode
<img width="498" alt="image" src="https://user-images.githubusercontent.com/12382440/104281436-ca988280-54ad-11eb-98c0-5129fe1354b9.png">

This change ensures that the block cursor in both cases uses the text accent color:
- Normal Mode
<img width="496" alt="image" src="https://user-images.githubusercontent.com/12382440/104281550-fa478a80-54ad-11eb-8bf5-c751b8ef637d.png">
- Visual Mode
<img width="504" alt="image" src="https://user-images.githubusercontent.com/12382440/104281512-ed2a9b80-54ad-11eb-9e23-cfcc09a4d165.png">

