### PR TITLE
Fix cut off graph controls

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -3819,10 +3819,6 @@ body:not(.plugin-sliding-panes-rotate-header) .workspace-leaf-content[data-type=
   background:transparent;}
 .mod-root .workspace-leaf-content[data-type='localgraph'] .graph-controls,
 .mod-root .workspace-leaf-content[data-type='graph'] .graph-controls {
-  top:30px;}
-
-.mod-root .workspace-leaf-content[data-type='localgraph'] .graph-controls,
-.mod-root .workspace-leaf-content[data-type='graph'] .graph-controls {
   top:var(--header-height);}
 
 

--- a/obsidian.css
+++ b/obsidian.css
@@ -3823,7 +3823,7 @@ body:not(.plugin-sliding-panes-rotate-header) .workspace-leaf-content[data-type=
 
 .mod-root .workspace-leaf-content[data-type='localgraph'] .graph-controls,
 .mod-root .workspace-leaf-content[data-type='graph'] .graph-controls {
-  top:30px;}
+  top:var(--header-height);}
 
 
 /* Graph controls */


### PR DESCRIPTION
While testing out release 4.0.0 I noticed that the closed, graph control icon was cut off a bit due to the header overlapping on top of it. It is a bit worse if the custom icons setting is turned off or if the `--header-height` variable is increased in a CSS snippet.

To fix this I adjusted the position of the graph controls based on the `--header-height` variable.

<details>
  <summary>Before</summary>
  
![image](https://user-images.githubusercontent.com/19917631/136495310-c3334275-2988-4afd-bc4c-a8148f75243e.png)
  
</details>

<details>
  <summary>After</summary>
    
![image](https://user-images.githubusercontent.com/19917631/136495215-3d9cd47a-19ad-4441-b897-bed0744dcc48.png)

</details>


I also noticed that there was a duplicate rule for the `.graph-controls` in the same spot so I removed it.

**Side Note**
With this change there is a bit of extra `padding-top` on the `.graph-controls.is-close` default Obsidian CSS rule. If we want a similar position I can add a rule to adjust that CSS and reduce the `padding-top` from `6px` to `2px`.

I hope you do not mind the PR. I didn't see a contributing guide, and I'm happy to make any changes suggested.