### PR TITLE
Add '-plugin' suffix to obsidian-dictionary

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -6448,7 +6448,7 @@ community:
 - calendar
 - obsidian-checklist-plugin
 - obsidian-codemirror-options
-- obsidian-dictionary
+- obsidian-dictionary-plugin
 - obsidian-excalidraw-plugin
 - obsidian-git
 - obsidian-hider


### PR DESCRIPTION
This is to fix a dangling link in the Obsidian Community Hub markdown files that are generated from this information.