### PR TITLE
Fix active folder's background reset when hovered

### DIFF
--- a/src/scss/obsidian/file-nav.scss
+++ b/src/scss/obsidian/file-nav.scss
@@ -64,6 +64,7 @@ body:not(.is-mobile) .nav-folder.mod-root>.nav-folder-title .nav-folder-title-co
 .nav-file-title.is-active,
 .nav-folder-title.is-active,
 .nav-file-title.is-being-dragged,
+body:not(.is-grabbing) .nav-folder-title.is-active:hover,
 body:not(.is-grabbing) .nav-folder-title:hover,
 body:not(.is-grabbing) .nav-file-title.is-active:hover {
   background-color:var(--background-tertiary);


### PR DESCRIPTION
In [latest version of alx-folder-note](https://github.com/aidenlx/alx-folder-note/releases/tag/0.14.0), I've add the `is-active` class for active folder's titleEl when a folder description note is active. However, in the latest version of minimal theme, the background color of active folder is broken when hovered (see screen recording below). I'm able to fix this with the following css snippet: 

```css
body:not(.is-grabbing) .nav-folder-title.is-active:hover {
  background-color: var(--background-tertiary);
  color: var(--text-normal);
}
```

https://user-images.githubusercontent.com/31102694/155692950-677230de-d9f5-4721-8066-476e72a670c2.mp4
