### PR TITLE
fix(gutter): line numbers no longer shift under active line

### DIFF
--- a/src/scss/obsidian/fonts.scss
+++ b/src/scss/obsidian/fonts.scss
@@ -79,6 +79,9 @@ em,
 .workspace-leaf.mod-active .view-header-title {
   color:var(--title-color);
 }
+.cm-s-obsidian .HyperMD-header { 
+  line-height: 1.3;
+}
 .mod-cm6 .cm-editor .HyperMD-header-1,
 .mod-cm6 .cm-editor .HyperMD-header-2,
 .mod-cm6 .cm-editor .HyperMD-header-3,


### PR DESCRIPTION
Hi Kepano, sorry I'm still figuring out how to properly commit the built grunt files. But this should fix a small issue where the line number gets pushed upwards on the active line.

## Issue:

https://user-images.githubusercontent.com/693981/158220388-1eb8bbcf-3e1a-465b-9825-013d4f394298.mov

This fix shouldn't actually affect the line-height and still looks the same visually. I think the issue is that the gutter is using the line-height of the `HyperMd-header` class with javascript to calculate the `margin-top`. So when the line becomes active, it's recalculating the margin-top and moving the gutter elements.
 