### PR TITLE
fix: add active state to file nav context menu

### DIFF
--- a/src/scss/obsidian/file-nav.scss
+++ b/src/scss/obsidian/file-nav.scss
@@ -47,6 +47,16 @@ body:not(.is-mobile) .nav-folder.mod-root>.nav-folder-title .nav-folder-title-co
   margin-left:-10px;
 }
 
+/* Fix :active state when right-clicking in file explorer */
+.nav-file-title.is-being-dragged,
+.nav-folder-title.is-being-dragged,
+body:not(.is-grabbing) .nav-file-title.is-being-dragged:hover,
+body:not(.is-grabbing) .nav-folder-title.is-being-dragged:hover {
+  background-color: var(--background-secondary-alt);
+  box-shadow: 0 0 0 2px var(--interactive-accent);
+  z-index: 1;
+}
+
 .nav-file {
   margin-left:12px;
   padding-right:4px;


### PR DESCRIPTION
This is an issue with the default Obsidian theme as well. When you right click on an item in the file explorer, there's not active state on the item. The white text is just coming from the `:hover`. I've found it annoying since there's no feedback in the UI until you move the mouse that the correct item is selected. 

This mimics the same styling as Finder when you right-click vs select a file.

### Before:

<img width="308" alt="image" src="https://user-images.githubusercontent.com/693981/158648445-2519d692-d493-49ba-aced-7b4ab24a4cbb.png">


### After:

<img width="388" alt="image" src="https://user-images.githubusercontent.com/693981/158648626-a1a2518a-7e61-4279-83da-70e4945faf3f.png">
