### PR TITLE
fix theme variable override built-in variable in v0.14.5+

### DIFF
--- a/src/scss/components/buttons.scss
+++ b/src/scss/components/buttons.scss
@@ -4,7 +4,7 @@ button {
 }
 button,
 .setting-item-control button {
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
   font-size:var(--font-inputs);
   font-weight:400;
 }

--- a/src/scss/components/dropdowns.scss
+++ b/src/scss/components/dropdowns.scss
@@ -1,7 +1,7 @@
 /* Dropdowns */
 .dropdown,
 body .addChoiceBox #addChoiceTypeSelector {
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
   font-size:var(--font-inputs);
 }
 .dropdown,
@@ -11,7 +11,7 @@ select {
   border-color:var(--background-modifier-border);
   transition:border-color 0.1s linear;
   height:var(--input-height);
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
 }
 .dropdown {
   background-image:url('data:image/svg+xml;charset=US-ASCII,<svg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22><path%20fill%3D%22%23000%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F><%2Fsvg>');

--- a/src/scss/components/inputs.scss
+++ b/src/scss/components/inputs.scss
@@ -5,7 +5,7 @@ input[type='search'],
 input[type='email'],
 input[type='password'],
 input[type='number'] {
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
   font-size:var(--font-inputs);
 }
 textarea {

--- a/src/scss/features/relationship-lines.scss
+++ b/src/scss/features/relationship-lines.scss
@@ -33,7 +33,7 @@ body.minimal-rel-edit .cm-hmd-list-indent > .cm-tab:after {
 /* Relationship lines in Live Preview, disabled now that Indentation Guides is available
 
 :root {
-  --indent-font-family:var(--text-editor);
+  --indent-font-family:var(--font-text);
   --indent-font-size:var(--font-adaptive-normal);
 }
 

--- a/src/scss/mobile/mobile.scss
+++ b/src/scss/mobile/mobile.scss
@@ -15,7 +15,7 @@
   display:none;
 }
 .is-mobile .follow-link-popover {
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
 }
 
 /* Padding reset */

--- a/src/scss/obsidian/fonts.scss
+++ b/src/scss/obsidian/fonts.scss
@@ -4,7 +4,7 @@ h1,h2,h3,h4,h5,strong {font-weight:var(--bold-weight);}
 h1,h2,h3,h4 {letter-spacing:-0.02em;} 
 
 body, input, button  {
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
 }
 .cm-s-obsidian span.cm-error {
   color:var(--red);
@@ -31,7 +31,7 @@ body, input, button,
 .cm-s-obsidian,
 .cm-s-obsidian span.cm-formatting-task {
   line-height:var(--line-height);
-  font-family:var(--text-editor);
+  font-family:var(--font-text);
   -webkit-font-smoothing:subpixel-antialiased;
 }
 
@@ -40,7 +40,7 @@ body, input, button,
   font-family:var(--text)
 }
 .cm-s-obsidian span.cm-formatting-task {
-  font-family:var(--text-editor);
+  font-family:var(--font-text);
   line-height:var(--line-height);
 }
 .cm-s-obsidian .cm-header,

--- a/src/scss/obsidian/fonts.scss
+++ b/src/scss/obsidian/fonts.scss
@@ -13,7 +13,7 @@ body, input, button  {
 .popover,
 .vertical-tab-content-container,
 .workspace-leaf-content[data-type=markdown] {
-  font-family:var(--text)
+  font-family:var(--font-text)
 }
 body, input, button,
 .markdown-preview-view,
@@ -37,7 +37,7 @@ body, input, button,
 
 /* Use reading font in live preview */
 .lp-reading-font .markdown-source-view.mod-cm6.is-live-preview .cm-scroller {
-  font-family:var(--text)
+  font-family:var(--font-text)
 }
 .cm-s-obsidian span.cm-formatting-task {
   font-family:var(--font-text);

--- a/src/scss/obsidian/frontmatter.scss
+++ b/src/scss/obsidian/frontmatter.scss
@@ -4,7 +4,7 @@
 .theme-light pre.frontmatter[class*="language-yaml"] {
   padding:0 0 0px 0;
   background:transparent;
-  font-family:var(--text);
+  font-family:var(--font-text);
   line-height:1.2;
   border-radius:0;
   border-bottom:0px solid var(--background-modifier-border);
@@ -15,7 +15,7 @@
 .theme-dark .frontmatter .token,
 .theme-light .frontmatter .token,
 .markdown-preview-section .frontmatter code {
-  font-family:var(--text);
+  font-family:var(--font-text);
   color:var(--text-faint) !important;
 }
 

--- a/src/scss/obsidian/frontmatter.scss
+++ b/src/scss/obsidian/frontmatter.scss
@@ -20,7 +20,7 @@
 }
 
 .markdown-source-view .cm-s-obsidian .cm-hmd-frontmatter {
-    font-family:var(--text-editor);
+    font-family:var(--font-text);
     color:var(--text-muted);
 }
 

--- a/src/scss/obsidian/tags.scss
+++ b/src/scss/obsidian/tags.scss
@@ -6,7 +6,7 @@ a.tag {
   border:var(--tag-border-width) solid var(--background-modifier-border);
   color:var(--tag-color);
   font-size:var(--font-adaptive-small);
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
   padding:1px 8px 1px;
   text-align:center;
   text-decoration:none;
@@ -25,7 +25,7 @@ a.tag:hover {
   border:var(--tag-border-width) solid var(--background-modifier-border);
   color:var(--tag-color);
   font-size:var(--font-adaptive-small);
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
   text-align:center;
   text-decoration:none;
   margin:0;

--- a/src/scss/plugins/dataview.scss
+++ b/src/scss/plugins/dataview.scss
@@ -43,7 +43,7 @@ ul .dataview .task-list-basic-item:hover {
 body .dataview.inline-field-key,
 body .dataview.inline-field-value,
 body .dataview .inline-field-standalone-value {
-  font-family:var(--text);
+  font-family:var(--font-text);
   font-size:calc(var(--font-adaptive-normal) - 2px);
   background:transparent;
   color:var(--text-muted);

--- a/src/scss/plugins/excalidraw.scss
+++ b/src/scss/plugins/excalidraw.scss
@@ -7,7 +7,7 @@ body .excalidraw.theme--dark {
   --color-primary-chubb:var(--interactive-accent-hover);
   --color-primary-darker:var(--interactive-accent-hover);
   --color-primary-darkest:var(--interactive-accent-hover);
-  --ui-font:var(--font-ui);
+  --ui-font:var(--font-interface);
   --island-bg-color:var(--background-secondary);
   --button-gray-1:var(--background-tertiary);
   --button-gray-2:var(--background-tertiary);
@@ -53,7 +53,7 @@ body .excalidraw .Island {
 }
 body .excalidraw .ToolIcon {
   cursor:var(--cursor);
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
   background-color:transparent;
 }
 body .excalidraw label.ToolIcon {

--- a/src/scss/plugins/kanban.scss
+++ b/src/scss/plugins/kanban.scss
@@ -1,7 +1,7 @@
 /* Kanban plugin */
 
 body .kanban-plugin__markdown-preview-view {
-  font-family:var(----text);
+  font-family:var(--font-text);
 }
 body .kanban-plugin {
   --interactive-accent:var(--text-selection);

--- a/src/scss/plugins/metatable.scss
+++ b/src/scss/plugins/metatable.scss
@@ -1,7 +1,7 @@
 /* Metatable */
 .obsidian-metatable {
   --metatable-font-size:calc(var(--font-adaptive-normal) - 2px);
-  --metatable-font-family: var(--font-ui);
+  --metatable-font-family: var(--font-interface);
   --metatable-background:transparent;
   --metatable-foreground: var(--text-faint);
   --metatable-key-background:transparent;

--- a/src/scss/plugins/tracker.scss
+++ b/src/scss/plugins/tracker.scss
@@ -7,7 +7,7 @@ body.theme-light {
 }
 
 .tracker-axis-label {
-  font-family:var(--font-ui);
+  font-family:var(--font-interface);
 }
 .tracker-axis {
   color:var(--ui2);

--- a/src/scss/variables/root.scss
+++ b/src/scss/variables/root.scss
@@ -5,9 +5,9 @@
 
   /* Fonts */
   --text:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
-  --text-editor:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
-  --font-monospace:Menlo,SFMono-Regular,Consolas,"Roboto Mono",monospace;
-  --font-ui:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  --font-text-theme:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  --font-monospace-theme:Menlo,SFMono-Regular,Consolas,"Roboto Mono",monospace;
+  --font-interface-theme:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 
   /* Font sizes */
   --font-normal:16px;

--- a/src/scss/variables/root.scss
+++ b/src/scss/variables/root.scss
@@ -4,7 +4,6 @@
   --cursor:default;
 
   /* Fonts */
-  --text:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
   --font-text-theme:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
   --font-monospace-theme:Menlo,SFMono-Regular,Consolas,"Roboto Mono",monospace;
   --font-interface-theme:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;


### PR DESCRIPTION
https://forum.obsidian.md/t/obsidian-release-v0-14-4-insider-build/35026#developers-4

this fix should allow obsidian's custom font settings to work properly

- `--text` variable for reading view and `--font-editor` for editor is merged into `--font-text-theme` since obsidian now intentionally use it in both live preview and reading mode to unify the appearance
- `--font-monospace` is replaced with `--font-monospace-theme` to avoid overriding custom font in obsidian's settings