### PR TITLE
Fix the indentation of the first line of codeblocks nested in a list item

### DIFF
--- a/src/scss/features/line-width.scss
+++ b/src/scss/features/line-width.scss
@@ -112,14 +112,14 @@
 	margin-left:0 !important;
 }
 
-/* 
+/*
 	Line width for Live Preview / Editor mode
 	Gets complicated.
 	-------------------------------------------*/
 
 	/* Nudge everything slightly to the left to make space for folding and gutters */
 	/* This is the big daddy rule for most editor content line types */
-	.markdown-source-view.mod-cm6.is-readable-line-width { 
+	.markdown-source-view.mod-cm6.is-readable-line-width {
 		.internal-embed,
 		.cm-content > .image-embed,
 		.cm-line,
@@ -162,7 +162,7 @@
 	}
 	/* For lists adding an extra offset value in Edit mode */
 	.markdown-source-view.mod-cm6.is-readable-line-width {
-		.HyperMD-list-line {
+		.HyperMD-list-line:not(.HyperMD-codeblock) {
 			width:calc(var(--line-width-adaptive) - var(--folding-offset) - var(--list-edit-offset));
 			max-width:calc(var(--max-width) - var(--folding-offset) - var(--list-edit-offset));
 			margin-right:auto;
@@ -172,7 +172,7 @@
 		}
 	}
 
-/* 
+/*
 Dataview lists/checklists
 A nightmare mainly because there is no selector that indicates
 a list is present inside the dataview block


### PR DESCRIPTION
Fixes #385.

**Before the change:**

<img width="680" alt="image" src="https://user-images.githubusercontent.com/34945306/183310935-4314ab46-726c-4948-8499-e96d8ccf5daf.png">

**After the change**:

<img width="668" alt="image" src="https://user-images.githubusercontent.com/34945306/183310922-97159356-d424-45f7-b41c-aaf89a420db8.png">
