### PR TITLE
Added additional specificity for checklist plugin

### DIFF
--- a/src/scss/plugins/checklist.scss
+++ b/src/scss/plugins/checklist.scss
@@ -46,7 +46,8 @@
 	margin:1px auto;
 	padding:0;
 }
-.checklist-plugin-main .group .classic .content {
+div .checklist-plugin-main .group .compact .content,
+div .checklist-plugin-main .group .classic .content {
 	padding:0;
 }
 .checklist-plugin-main .group .classic:hover,


### PR DESCRIPTION
Something in the new 1.0 appearance update causes the checklist plugin css to override minimal theme - this adds additional specificity so that it correctly wins over checklist's css.

This is the resulting CSS in classic:
![image](https://user-images.githubusercontent.com/791577/195706231-2ae2cb10-2f44-406c-84cc-4b6d2387e532.png)

and compact:
![image](https://user-images.githubusercontent.com/791577/195706276-dc85cbfc-577e-4704-9d60-6bb57f243a88.png)

This is what was previously happening - note `padding: 0` not being picked as highest priority style.

Compact:
![image](https://user-images.githubusercontent.com/791577/195706464-3beca6d2-d831-4929-bd9f-b7c1e109bbd0.png)

Classic:
![image](https://user-images.githubusercontent.com/791577/195706495-eed9d7ee-cde9-446c-8c2d-a8fa1f59ce90.png)
