### PR TITLE
fix: add external-embed selector to line-width to align new embed style

### DIFF
--- a/src/scss/features/line-width.scss
+++ b/src/scss/features/line-width.scss
@@ -112,14 +112,14 @@
 	margin-left:0 !important;
 }
 
-/* 
+/*
 	Line width for Live Preview / Editor mode
 	Gets complicated.
 	-------------------------------------------*/
 
 	/* Nudge everything slightly to the left to make space for folding and gutters */
 	/* This is the big daddy rule for most editor content line types */
-	.markdown-source-view.mod-cm6.is-readable-line-width { 
+	.markdown-source-view.mod-cm6.is-readable-line-width {
 		.internal-embed,
 		.cm-content > .image-embed,
 		.cm-line,
@@ -128,6 +128,7 @@
 		.embedded-backlinks,
 		.cm-embed-block.cm-callout > .callout,
 		.cm-html-embed,
+		.external-embed,
 		.cm-content > img:not([width]),
 		table {
 			width:calc(var(--line-width-adaptive) - var(--folding-offset));
@@ -172,7 +173,7 @@
 		}
 	}
 
-/* 
+/*
 Dataview lists/checklists
 A nightmare mainly because there is no selector that indicates
 a list is present inside the dataview block


### PR DESCRIPTION
The new embed feature in Obsidian (`![](https://youtube.com)`) does not apply the `.cm-html-embed` selector but instead uses `.external-embed`. 

Related: #572

This is resulting in the new embeds not being centered in the container. 

<img width="1641" alt="Screenshot 2023-06-05 at 6 08 56 PM" src="https://github.com/kepano/obsidian-minimal/assets/11879736/97056683-adc1-41d0-b125-dd6501d210c9">

Adding the `.external-embed` selector to the line-width source view block fixes this. 
<img width="1649" alt="Screenshot 2023-06-05 at 6 08 13 PM" src="https://github.com/kepano/obsidian-minimal/assets/11879736/b6fd1252-22a2-44f4-9cef-f6e3115b8801">

