### PR TITLE
Fix dataview table style when a table has error message

### DIFF
--- a/src/scss/plugins/dataview.scss
+++ b/src/scss/plugins/dataview.scss
@@ -91,7 +91,7 @@ body div.dataview-error-box {
 	}
 }
 
-.block-language-dataviewjs:has(.dataview-error-box) table.dataview {
+table.dataview:has(+ .dataview-error-box) {
 	display: none;
 }
 


### PR DESCRIPTION
Fix #649.

Only hide the error one.