### PR TITLE
Remove Sortable from READ.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Most plugins work well with Minimal, but the following plugins have received spe
 - [Leaflet](https://github.com/valentine195/obsidian-leaflet-plugin) for maps
 - [Outliner](https://github.com/vslinko/obsidian-outliner)
 - [QuickAdd](https://github.com/chhoumann/quickadd)
-- [Sortable](https://github.com/alexandru-dinu/obsidian-sortable) — recommended for cards and tables
 
 ## Helper filters and classes
 


### PR DESCRIPTION
On March 12th, Sortable was archived which means that newcomers to Minimal cannot access it and may become confused. 

Ticket #716 