### PR TITLE
Update copyright dates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
 Minimal Theme compiler for Obsidian
 
 MIT License
-Copyright (c) 2020-2021 Stephan Ango (@kepano)
+Copyright (c) 2020-2024 Stephan Ango (@kepano)
 
 Grunt is JS library that runs a sequence of compilation tasks, and watches 
 the working files to automatically run this sequence whenever changes happen. 

--- a/obsidian.css
+++ b/obsidian.css
@@ -24,7 +24,7 @@ https://github.com/kepano/obsidian-minimal
 
 MIT License
 
-Copyright (c) 2020-2022 Stephan Ango (@kepano)
+Copyright (c) 2020-2024 Stephan Ango (@kepano)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/css/license.css
+++ b/src/css/license.css
@@ -17,7 +17,7 @@ https://github.com/kepano/obsidian-minimal
 
 MIT License
 
-Copyright (c) 2020-2023 Stephan Ango (@kepano)
+Copyright (c) 2020-2024 Stephan Ango (@kepano)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -7173,7 +7173,7 @@ https://github.com/sainnhe/everforest
 /*
 Flexoki
 MIT License
-Copyright (c) 2023 Steph Ango
+Copyright (c) 2024 Steph Ango
 https://stephango.com/flexoki
 */
 .theme-light.minimal-flexoki-light {

--- a/src/scss/color-schemes/flexoki.scss
+++ b/src/scss/color-schemes/flexoki.scss
@@ -1,7 +1,7 @@
 /*
 Flexoki
 MIT License
-Copyright (c) 2023 Steph Ango
+Copyright (c) 2024 Steph Ango
 https://stephango.com/flexoki
 */
 


### PR DESCRIPTION
Match the copyright dates of the different files with the one in LICENSE.

There are still three outdated copyrights:
- Two in obsidian-minimal/Minimal.css
- One in obsidian-minimal/theme.css

The warning _"We've detected the file has mixed line endings. When you commit changes we will normalize them to Windows-style"_ stopped me and I preferred to revert those changes.

I also found several _Stephan Ango_ vs _Steph Ango_, and other outdated external copyrights to Minimal/Flexokiex that I ignored to edit.