### PR TITLE
Fixed E-Ink result color problem

### DIFF
--- a/src/scss/color-schemes/eink.scss
+++ b/src/scss/color-schemes/eink.scss
@@ -33,7 +33,6 @@
 	--text-on-accent-inverted: var(--bg1);
 	--text-selection: var(--tx1);
 	--vault-profile-color: var(--tx1);
-	--nav-item-color-active: var(--bg1);
 	--nav-item-color-hover: var(--bg1);
 
 	button:hover,


### PR DESCRIPTION
The problem can be seen in, for instance, the backlinks area where the result text is in the same color as the background.