### PR TITLE
Fix broken --modal-border in minimal-dark-black (stray tab fused two declarations)

### DIFF
--- a/Minimal.css
+++ b/Minimal.css
@@ -592,7 +592,7 @@ body .excalidraw {
   --background-primary-alt: var(--bg3);
   --background-table-rows: var(--bg3);
   --setting-items-background: black;
-  --setting-items-border-width: 1px	--modal-border: var(--ui2);
+  --modal-border: var(--ui2);
   --active-line-bg: rgba(255,255,255,0.085);
   --background-modifier-form-field: var(--bg3);
   --background-modifier-cover:hsla(var(--base-h),var(--base-s),calc(var(--base-d) + 8%),0.7);

--- a/src/scss/variables/theme.scss
+++ b/src/scss/variables/theme.scss
@@ -193,7 +193,7 @@
 	--background-primary-alt:    var(--bg3);
 	--background-table-rows:     var(--bg3);
 	--setting-items-background:  black;
-	--setting-items-border-width: 1px	--modal-border:              var(--ui2);
+	--modal-border:              var(--ui2);
 
 	--active-line-bg: rgba(255,255,255,0.085);
 

--- a/theme.css
+++ b/theme.css
@@ -592,7 +592,7 @@ body .excalidraw {
   --background-primary-alt: var(--bg3);
   --background-table-rows: var(--bg3);
   --setting-items-background: black;
-  --setting-items-border-width: 1px	--modal-border: var(--ui2);
+  --modal-border: var(--ui2);
   --active-line-bg: rgba(255,255,255,0.085);
   --background-modifier-form-field: var(--bg3);
   --background-modifier-cover:hsla(var(--base-h),var(--base-s),calc(var(--base-d) + 8%),0.7);


### PR DESCRIPTION
In `496802e` ("Small fixes for scrollbars and settings"), the `.theme-dark.minimal-dark-black` block ended up with a tab instead of a `;` + newline between two custom properties:

```css
--setting-items-border-width: 1px	--modal-border: var(--ui2);
```

Because custom properties accept almost any token sequence, `--setting-items-border-width` swallows the rest of the line and `--modal-border` is dropped entirely, so the dark-black modal border no longer resolves to `var(--ui2)`.

`--setting-items-border-width: 1px` is already provided by the new nested `.theme-dark.minimal-dark-black .mod-settings { ... }` block (consistent with the other variants), so this restores `--modal-border: var(--ui2);` on its own line and drops the redundant fused declaration.

Updated the SCSS source (`src/scss/variables/theme.scss`) and both compiled outputs (`theme.css`, `Minimal.css`).