### PR TITLE
Fix Obsidian Git Split diff gutter layout

### DIFF
--- a/src/scss/app/editor.scss
+++ b/src/scss/app/editor.scss
@@ -29,7 +29,7 @@
 }
 
 /* Gutters */
-body :not(.canvas-node) .markdown-source-view.mod-cm6 .cm-gutters {
+body :not(.canvas-node) .markdown-source-view.mod-cm6:not(.git-split-diff-view) .cm-gutters {
 	position:absolute !important;
 	z-index:0;
 	margin-inline-end: 0;


### PR DESCRIPTION
# Fix Obsidian Git Split diff gutter layout

Closes kepano/obsidian-minimal#902.

## Problem

Obsidian Git's Split diff creates a CodeMirror MergeView inside a container with `markdown-source-view mod-cm6`. Minimal's general gutter rule therefore applies to MergeView gutters and forces `position: absolute !important`, causing the gutter to overlap editor content.

## Change

Exclude the verified `.git-split-diff-view` root from the existing general gutter-positioning selector in `src/scss/app/editor.scss`.

## Why this is targeted

The change applies only when Obsidian Git marks the Split diff root with `.git-split-diff-view`. Normal Markdown editors retain Minimal's current gutter behavior; no generic CodeMirror or MergeView selector is changed.

## Compatibility context

Minimal's absolute-gutter behavior predates Obsidian Git Split by over two years. Obsidian Git introduced Split in December 2024 and marks its MergeView container as both `markdown-source-view` and `mod-cm6`, which unintentionally matches Minimal's ordinary-editor selector. This exception keeps the intended behavior for standard editors while preserving CodeMirror MergeView's layout contract.

## Verification

- `npm ci`
- `npm run build`
- `git diff --check`
- Confirmed that generated `theme.css` contains the expected exclusion.

## Risk

Low. The selector relies on an Obsidian Git class verified in version 2.38.6. A future Obsidian Git rename would merely stop the exception from applying, rather than changing normal editor behavior.
